### PR TITLE
1.19.2 Port

### DIFF
--- a/common/src/main/java/com/finndog/mes/misc/pooladditions/PoolAdditionMerger.java
+++ b/common/src/main/java/com/finndog/mes/misc/pooladditions/PoolAdditionMerger.java
@@ -18,7 +18,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -58,7 +57,7 @@ public final class PoolAdditionMerger {
      * Afterwards, it will merge the parsed pool into the targeted pool found in the dynamic registry.
      */
     private static void parsePoolsAndBeginMerger(Map<ResourceLocation, List<JsonElement>> poolAdditionJSON, RegistryAccess dynamicRegistryManager, StructureTemplateManager StructureTemplateManager) {
-        Registry<StructureTemplatePool> poolRegistry = dynamicRegistryManager.registryOrThrow(Registries.TEMPLATE_POOL);
+        Registry<StructureTemplatePool> poolRegistry = dynamicRegistryManager.registryOrThrow(Registry.TEMPLATE_POOL_REGISTRY);
         RegistryOps<JsonElement> customRegistryOps = RegistryOps.create(JsonOps.INSTANCE, dynamicRegistryManager);
 
         // Will iterate over all of our found pool additions and make sure the target pool exists before we parse our JSON objects
@@ -150,15 +149,15 @@ public final class PoolAdditionMerger {
 
         public static final Codec<AdditionalStructureTemplatePool> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance.group(
                 ResourceLocation.CODEC.fieldOf("name").forGetter(structureTemplatePool -> structureTemplatePool.name),
-                ExtraCodecs.lazyInitializedCodec(StructurePoolAccessor.getCODEC_REFERENCE()::getValue).fieldOf("fallback").forGetter(StructureTemplatePool::getFallback),
+                ResourceLocation.CODEC.fieldOf("fallback").forGetter(StructureTemplatePool::getFallback),
                 EXPANDED_POOL_ENTRY_CODEC.listOf().fieldOf("elements").forGetter(structureTemplatePool -> structureTemplatePool.rawTemplatesWithConditions)
         ).apply(instance, AdditionalStructureTemplatePool::new));
 
         protected final List<ExpandedPoolEntry> rawTemplatesWithConditions;
         protected final ResourceLocation name;
 
-        public AdditionalStructureTemplatePool(ResourceLocation name, Holder<StructureTemplatePool> fallback, List<ExpandedPoolEntry> rawTemplatesWithConditions) {
-            super(fallback, rawTemplatesWithConditions.stream().map(triple -> Pair.of(triple.poolElement(), triple.weight())).collect(Collectors.toList()));
+        public AdditionalStructureTemplatePool(ResourceLocation name, ResourceLocation fallback, List<ExpandedPoolEntry> rawTemplatesWithConditions) {
+            super(name, fallback, rawTemplatesWithConditions.stream().map(triple -> Pair.of(triple.poolElement(), triple.weight())).collect(Collectors.toList()));
             this.rawTemplatesWithConditions = rawTemplatesWithConditions;
             this.name = name;
         }

--- a/common/src/main/java/com/finndog/mes/mixins/structures/LocateCommandMixin.java
+++ b/common/src/main/java/com/finndog/mes/mixins/structures/LocateCommandMixin.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.arguments.ResourceOrTagKeyArgument;
+import net.minecraft.commands.arguments.ResourceOrTagLocationArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
@@ -35,19 +35,13 @@ public class LocateCommandMixin {
      * @author - TelepathicGrunt
      */
     @Inject(
-            method = "locateStructure(Lnet/minecraft/commands/CommandSourceStack;Lnet/minecraft/commands/arguments/ResourceOrTagKeyArgument$Result;)I",
+            method = "locateStructure",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/chunk/ChunkGenerator;findNearestMapStructure(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/HolderSet;Lnet/minecraft/core/BlockPos;IZ)Lcom/mojang/datafixers/util/Pair;", ordinal = 0),
             locals = LocalCapture.CAPTURE_FAILSOFT,
             cancellable = true,
             require = 0
     )
-    private static void mes_increaseLocateRadius(CommandSourceStack commandSourceStack,
-                                                                  ResourceOrTagKeyArgument.Result<Structure> result,
-                                                                  CallbackInfoReturnable<Integer> cir,
-                                                                  Registry<Structure> registry,
-                                                                  HolderSet<Structure> holderSet,
-                                                                  BlockPos blockPos,
-                                                                  ServerLevel serverLevel) throws CommandSyntaxException {
+    private static void mes_increaseLocateRadius(CommandSourceStack commandSourceStack, ResourceOrTagLocationArgument.Result<Structure> result, CallbackInfoReturnable<Integer> cir, Registry<Structure> registry, HolderSet<Structure> holderSet, BlockPos blockPos, ServerLevel serverLevel) throws CommandSyntaxException {
         if(holderSet.stream().anyMatch(configuredStructureFeatureHolder -> configuredStructureFeatureHolder.is(MESTags.LARGER_LOCATE_SEARCH))) {
             int increasedSearchRadius = 2000;
             Stopwatch stopwatch = Stopwatch.createStarted(Util.TICKER);
@@ -57,7 +51,7 @@ public class LocateCommandMixin {
                 throw ERROR_STRUCTURE_NOT_FOUND.create(result.asPrintable());
             }
             else {
-                cir.setReturnValue(LocateCommand.showLocateResult(commandSourceStack, result, blockPos, pair, "commands.locate.structure.success", false, stopwatch.elapsed()));
+                cir.setReturnValue(LocateCommand.showLocateResult(commandSourceStack, result, blockPos, pair, "commands.locate.structure.success", false));
             }
         }
     }

--- a/common/src/main/java/com/finndog/mes/mixins/structures/StructurePoolAccessor.java
+++ b/common/src/main/java/com/finndog/mes/mixins/structures/StructurePoolAccessor.java
@@ -15,11 +15,6 @@ import java.util.List;
 
 @Mixin(StructureTemplatePool.class)
 public interface StructurePoolAccessor {
-    @Accessor("CODEC_REFERENCE")
-    static MutableObject<Codec<Holder<StructureTemplatePool>>> getCODEC_REFERENCE() {
-        throw new UnsupportedOperationException();
-    }
-
     @Accessor("rawTemplates")
     List<Pair<StructurePoolElement, Integer>> mes_getRawTemplates();
 

--- a/common/src/main/java/com/finndog/mes/modinit/MESPlacements.java
+++ b/common/src/main/java/com/finndog/mes/modinit/MESPlacements.java
@@ -7,11 +7,11 @@ import com.finndog.mes.modinit.registry.ResourcefulRegistry;
 import com.finndog.mes.world.placements.MinusEightPlacement;
 import com.finndog.mes.world.placements.SnapToLowerNonAirPlacement;
 import com.finndog.mes.world.placements.UnlimitedCountPlacement;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
 
 public final class MESPlacements {
-	public static final ResourcefulRegistry<PlacementModifierType<?>> PLACEMENT_MODIFIER = ResourcefulRegistries.create(BuiltInRegistries.PLACEMENT_MODIFIER_TYPE, MESCommon.MODID);
+	public static final ResourcefulRegistry<PlacementModifierType<?>> PLACEMENT_MODIFIER = ResourcefulRegistries.create(Registry.PLACEMENT_MODIFIERS, MESCommon.MODID);
 
 	public static final RegistryEntry<PlacementModifierType<MinusEightPlacement>> MINUS_EIGHT_PLACEMENT = PLACEMENT_MODIFIER.register("minus_eight_placement", () -> () -> MinusEightPlacement.CODEC);
 	public static final RegistryEntry<PlacementModifierType<UnlimitedCountPlacement>> UNLIMITED_COUNT = PLACEMENT_MODIFIER.register("unlimited_count", () -> () -> UnlimitedCountPlacement.CODEC);

--- a/common/src/main/java/com/finndog/mes/modinit/MESProcessors.java
+++ b/common/src/main/java/com/finndog/mes/modinit/MESProcessors.java
@@ -5,11 +5,11 @@ import com.finndog.mes.modinit.registry.RegistryEntry;
 import com.finndog.mes.modinit.registry.ResourcefulRegistries;
 import com.finndog.mes.modinit.registry.ResourcefulRegistry;
 import com.finndog.mes.world.processors.WaterloggingFixProcessor;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 
 public final class MESProcessors {
-    public static final ResourcefulRegistry<StructureProcessorType<?>> STRUCTURE_PROCESSOR = ResourcefulRegistries.create(BuiltInRegistries.STRUCTURE_PROCESSOR, MESCommon.MODID);
+    public static final ResourcefulRegistry<StructureProcessorType<?>> STRUCTURE_PROCESSOR = ResourcefulRegistries.create(Registry.STRUCTURE_PROCESSOR, MESCommon.MODID);
 
     public static final RegistryEntry<StructureProcessorType<WaterloggingFixProcessor>> WATERLOGGING_FIX_PROCESSOR = STRUCTURE_PROCESSOR.register("waterlogging_fix_processor", () -> () -> WaterloggingFixProcessor.CODEC);
 }

--- a/common/src/main/java/com/finndog/mes/modinit/MESStructurePieces.java
+++ b/common/src/main/java/com/finndog/mes/modinit/MESStructurePieces.java
@@ -6,14 +6,14 @@ import com.finndog.mes.modinit.registry.ResourcefulRegistries;
 import com.finndog.mes.modinit.registry.ResourcefulRegistry;
 import com.finndog.mes.world.structures.pieces.LegacyOceanBottomSinglePoolElement;
 import com.finndog.mes.world.structures.pieces.MirroringSingleJigsawPiece;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.world.level.levelgen.structure.pieces.StructurePieceType;
 import net.minecraft.world.level.levelgen.structure.pools.StructurePoolElementType;
 
 
 public final class MESStructurePieces {
-    public static final ResourcefulRegistry<StructurePoolElementType<?>> STRUCTURE_POOL_ELEMENT = ResourcefulRegistries.create(BuiltInRegistries.STRUCTURE_POOL_ELEMENT, MESCommon.MODID);
-    public static final ResourcefulRegistry<StructurePieceType> STRUCTURE_PIECE = ResourcefulRegistries.create(BuiltInRegistries.STRUCTURE_PIECE, MESCommon.MODID);
+    public static final ResourcefulRegistry<StructurePoolElementType<?>> STRUCTURE_POOL_ELEMENT = ResourcefulRegistries.create(Registry.STRUCTURE_POOL_ELEMENT, MESCommon.MODID);
+    public static final ResourcefulRegistry<StructurePieceType> STRUCTURE_PIECE = ResourcefulRegistries.create(Registry.STRUCTURE_PIECE, MESCommon.MODID);
 
     public static final RegistryEntry<StructurePoolElementType<MirroringSingleJigsawPiece>> MIRROR_SINGLE = STRUCTURE_POOL_ELEMENT.register("mirroring_single_pool_element", () -> () -> MirroringSingleJigsawPiece.CODEC);
     public static final RegistryEntry<StructurePoolElementType<LegacyOceanBottomSinglePoolElement>> LEGACY_OCEAN_BOTTOM = STRUCTURE_POOL_ELEMENT.register("legacy_ocean_bottom_single_pool_element", () -> () -> LegacyOceanBottomSinglePoolElement.CODEC);

--- a/common/src/main/java/com/finndog/mes/modinit/MESStructurePlacementType.java
+++ b/common/src/main/java/com/finndog/mes/modinit/MESStructurePlacementType.java
@@ -5,12 +5,12 @@ import com.finndog.mes.modinit.registry.RegistryEntry;
 import com.finndog.mes.modinit.registry.ResourcefulRegistries;
 import com.finndog.mes.modinit.registry.ResourcefulRegistry;
 import com.finndog.mes.world.structures.placements.AdvancedRandomSpread;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.world.level.levelgen.structure.placement.StructurePlacementType;
 
 
 public final class MESStructurePlacementType {
-    public static final ResourcefulRegistry<StructurePlacementType<?>> STRUCTURE_PLACEMENT_TYPE = ResourcefulRegistries.create(BuiltInRegistries.STRUCTURE_PLACEMENT, MESCommon.MODID);
+    public static final ResourcefulRegistry<StructurePlacementType<?>> STRUCTURE_PLACEMENT_TYPE = ResourcefulRegistries.create(Registry.STRUCTURE_PLACEMENT_TYPE, MESCommon.MODID);
 
     public static final RegistryEntry<StructurePlacementType<AdvancedRandomSpread>> ADVANCED_RANDOM_SPREAD = STRUCTURE_PLACEMENT_TYPE.register("advanced_random_spread", () -> () -> AdvancedRandomSpread.CODEC);
 }

--- a/common/src/main/java/com/finndog/mes/modinit/MESStructures.java
+++ b/common/src/main/java/com/finndog/mes/modinit/MESStructures.java
@@ -6,12 +6,12 @@ import com.finndog.mes.modinit.registry.ResourcefulRegistries;
 import com.finndog.mes.modinit.registry.ResourcefulRegistry;
 import com.finndog.mes.world.structures.GenericJigsawStructure;
 import com.finndog.mes.world.structures.GenericNetherJigsawStructure;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.world.level.levelgen.structure.StructureType;
 
 
 public final class MESStructures {
-    public static final ResourcefulRegistry<StructureType<?>> STRUCTURE_TYPE = ResourcefulRegistries.create(BuiltInRegistries.STRUCTURE_TYPE, MESCommon.MODID);
+    public static final ResourcefulRegistry<StructureType<?>> STRUCTURE_TYPE = ResourcefulRegistries.create(Registry.STRUCTURE_TYPES, MESCommon.MODID);
 
     public static RegistryEntry<StructureType<GenericJigsawStructure>> GENERIC_JIGSAW_STRUCTURE = STRUCTURE_TYPE.register("mes_generic_jigsaw_structure", () -> () -> GenericJigsawStructure.CODEC);
     public static RegistryEntry<StructureType<GenericNetherJigsawStructure>> GENERIC_NETHER_JIGSAW_STRUCTURE = STRUCTURE_TYPE.register("mes_generic_nether_jigsaw_structure", () -> () -> GenericNetherJigsawStructure.CODEC);

--- a/common/src/main/java/com/finndog/mes/modinit/MESTags.java
+++ b/common/src/main/java/com/finndog/mes/modinit/MESTags.java
@@ -1,7 +1,7 @@
 package com.finndog.mes.modinit;
 
 import com.finndog.mes.MESCommon;
-import net.minecraft.core.registries.Registries;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.levelgen.structure.Structure;
@@ -9,7 +9,7 @@ import net.minecraft.world.level.levelgen.structure.Structure;
 public final class MESTags {
     public static void initTags() {}
 
-    public static TagKey<Structure> LARGER_LOCATE_SEARCH = TagKey.create(Registries.STRUCTURE,
+    public static TagKey<Structure> LARGER_LOCATE_SEARCH = TagKey.create(Registry.STRUCTURE_REGISTRY,
             new ResourceLocation(MESCommon.MODID, "larger_locate_search"));
 
 }

--- a/common/src/main/java/com/finndog/mes/utils/GeneralUtils.java
+++ b/common/src/main/java/com/finndog/mes/utils/GeneralUtils.java
@@ -3,21 +3,18 @@ package com.finndog.mes.utils;
 import com.finndog.mes.MESCommon;
 import com.finndog.mes.mixins.resources.NamespaceResourceManagerAccessor;
 import com.finndog.mes.mixins.resources.ReloadableResourceManagerImplAccessor;
+import com.finndog.mes.modinit.registry.ResourcefulRegistries;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.mojang.datafixers.util.Pair;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.core.FrontAndTop;
-import net.minecraft.core.Vec3i;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.*;
+import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.packs.PackResources;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.FallbackResourceManager;
-import net.minecraft.server.packs.resources.IoSupplier;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.GsonHelper;
@@ -40,7 +37,6 @@ import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.StructurePiece;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
-import net.minecraft.world.level.storage.loot.LootDataType;
 import net.minecraft.world.level.storage.loot.LootTable;
 
 import java.io.BufferedReader;
@@ -104,7 +100,7 @@ public final class GeneralUtils {
 
                 // Exit early if facing open space opposite of wall
                 mutable.move(facing.getOpposite(), 2);
-                if(!blockView.getBlockState(mutable).isSolid()) {
+                if(!blockView.getBlockState(mutable).getMaterial().isSolid()) {
                     break;
                 }
             }
@@ -118,7 +114,7 @@ public final class GeneralUtils {
 
     public static ItemStack enchantRandomly(RandomSource random, ItemStack itemToEnchant, float chance) {
         if(random.nextFloat() < chance) {
-            List<Enchantment> list = BuiltInRegistries.ENCHANTMENT.stream().filter(Enchantment::isDiscoverable)
+            List<Enchantment> list = Registry.ENCHANTMENT.stream().filter(Enchantment::isDiscoverable)
                     .filter((enchantmentToCheck) -> enchantmentToCheck.canEnchant(itemToEnchant)).toList();
             if(!list.isEmpty()) {
                 Enchantment enchantment = list.get(random.nextInt(list.size()));
@@ -197,7 +193,7 @@ public final class GeneralUtils {
     }
 
     private static boolean isReplaceableByStructures(BlockState blockState) {
-        return blockState.isAir() || !blockState.getFluidState().isEmpty() || blockState.is(BlockTags.REPLACEABLE_BY_TREES);
+        return blockState.isAir() || !blockState.getFluidState().isEmpty() /* FIXME || blockState.is(BlockTags.REPLACEABLE_BY_TREES)*/;
     }
 
     //////////////////////////////////////////////
@@ -218,9 +214,9 @@ public final class GeneralUtils {
 
     // More optimized with checking if the jigsaw blocks can connect
     public static boolean canJigsawsAttach(StructureTemplate.StructureBlockInfo jigsaw1, StructureTemplate.StructureBlockInfo jigsaw2) {
-        FrontAndTop prop1 = jigsaw1.state().getValue(JigsawBlock.ORIENTATION);
-        FrontAndTop prop2 = jigsaw2.state().getValue(JigsawBlock.ORIENTATION);
-        String joint = jigsaw1.nbt().getString("joint");
+        FrontAndTop prop1 = jigsaw1.state.getValue(JigsawBlock.ORIENTATION);
+        FrontAndTop prop2 = jigsaw2.state.getValue(JigsawBlock.ORIENTATION);
+        String joint = jigsaw1.nbt.getString("joint");
         if(joint.isEmpty()) {
             joint = prop1.front().getAxis().isHorizontal() ? "aligned" : "rollable";
         }
@@ -228,7 +224,7 @@ public final class GeneralUtils {
         boolean isRollable = joint.equals("rollable");
         return prop1.front() == prop2.front().getOpposite() &&
                 (isRollable || prop1.top() == prop2.top()) &&
-                jigsaw1.nbt().getString("target").equals(jigsaw2.nbt().getString("name"));
+                jigsaw1.nbt.getString("target").equals(jigsaw2.nbt.getString("name"));
     }
 
     //////////////////////////////////////////////
@@ -248,11 +244,7 @@ public final class GeneralUtils {
         for (FallbackResourceManager.PackEntry packEntry : allResourcePacks) {
             PackResources resourcePack = packEntry.resources();
             if (resourcePack != null) {
-                IoSupplier<InputStream> IoSupplier = resourcePack.getResource(PackType.SERVER_DATA, fileID);
-                if (IoSupplier != null) {
-                    InputStream inputStream = IoSupplier.get();
-                    fileStreams.add(inputStream);
-                }
+                fileStreams.add(resourcePack.getResource(PackType.SERVER_DATA, fileID));
             }
         }
 
@@ -319,11 +311,11 @@ public final class GeneralUtils {
 
     public static boolean isInvalidLootTableFound(MinecraftServer minecraftServer, Map.Entry<ResourceLocation, ResourceLocation> entry) {
         boolean invalidLootTableFound = false;
-        if(minecraftServer.getLootData().getLootTable(entry.getKey()) == LootTable.EMPTY) {
+        if(minecraftServer.getLootTables().get(entry.getKey()) == LootTable.EMPTY) {
             MESCommon.LOGGER.error("Unable to find loot table key: {}", entry.getKey());
             invalidLootTableFound = true;
         }
-        if(minecraftServer.getLootData().getLootTable(entry.getValue()) == LootTable.EMPTY) {
+        if(minecraftServer.getLootTables().get(entry.getValue()) == LootTable.EMPTY) {
             MESCommon.LOGGER.error("Unable to find loot table value: {}", entry.getValue());
             invalidLootTableFound = true;
         }
@@ -332,7 +324,7 @@ public final class GeneralUtils {
 
     public static boolean isMissingLootImporting(MinecraftServer minecraftServer, Set<ResourceLocation> tableKeys) {
         AtomicBoolean invalidLootTableFound = new AtomicBoolean(false);
-        minecraftServer.getLootData().getKeys(LootDataType.TABLE).forEach(rl -> {
+        minecraftServer.getLootTables().getIds().forEach(rl -> {
             if(rl.getNamespace().equals(MESCommon.MODID) && !tableKeys.contains(rl)) {
                 if(rl.getPath().contains("mansions") && rl.getPath().contains("storage")) {
                     return;

--- a/common/src/main/java/com/finndog/mes/world/processors/WaterloggingFixProcessor.java
+++ b/common/src/main/java/com/finndog/mes/world/processors/WaterloggingFixProcessor.java
@@ -21,17 +21,17 @@ public class WaterloggingFixProcessor extends StructureProcessor {
 
     @Override
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader, BlockPos pos, BlockPos pos2, StructureTemplate.StructureBlockInfo infoIn1, StructureTemplate.StructureBlockInfo infoIn2, StructurePlaceSettings settings) {
-        if(!infoIn2.state().getFluidState().isEmpty()) {
-            if(levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(new ChunkPos(infoIn2.pos()))) {
+        if(!infoIn2.state.getFluidState().isEmpty()) {
+            if(levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(new ChunkPos(infoIn2.pos))) {
                 return infoIn2;
             }
 
-            ChunkAccess chunk = levelReader.getChunk(infoIn2.pos());
+            ChunkAccess chunk = levelReader.getChunk(infoIn2.pos);
             int minY = chunk.getMinBuildHeight();
             int maxY = chunk.getMaxBuildHeight();
-            int currentY = infoIn2.pos().getY();
+            int currentY = infoIn2.pos.getY();
             if(currentY >= minY && currentY <= maxY) {
-                ((LevelAccessor) levelReader).scheduleTick(infoIn2.pos(), infoIn2.state().getBlock(), 0);
+                ((LevelAccessor) levelReader).scheduleTick(infoIn2.pos, infoIn2.state.getBlock(), 0);
             }
         }
         return infoIn2;

--- a/common/src/main/java/com/finndog/mes/world/structures/GenericJigsawStructure.java
+++ b/common/src/main/java/com/finndog/mes/world/structures/GenericJigsawStructure.java
@@ -14,7 +14,7 @@ import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
-import net.minecraft.core.registries.Registries;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.ChunkPos;
@@ -222,7 +222,7 @@ public class GenericJigsawStructure extends Structure {
                 context,
                 this.startPool,
                 this.size,
-                context.registryAccess().registryOrThrow(Registries.STRUCTURE).getKey(this),
+                context.registryAccess().registryOrThrow(Registry.STRUCTURE_REGISTRY).getKey(this),
                 blockpos,
                 this.useBoundingBoxHack,
                 this.projectStartToHeightmap,

--- a/common/src/main/java/com/finndog/mes/world/structures/pieces/PieceLimitedJigsawManager.java
+++ b/common/src/main/java/com/finndog/mes/world/structures/pieces/PieceLimitedJigsawManager.java
@@ -14,7 +14,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
 import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.Pools;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
@@ -75,7 +74,7 @@ public class PieceLimitedJigsawManager {
             BiConsumer<StructurePiecesBuilder, List<PoolElementStructurePiece>> structureBoundsAdjuster
     ) {
         // Get jigsaw pool registry
-        Registry<StructureTemplatePool> jigsawPoolRegistry = context.registryAccess().registryOrThrow(Registries.TEMPLATE_POOL);
+        Registry<StructureTemplatePool> jigsawPoolRegistry = context.registryAccess().registryOrThrow(Registry.TEMPLATE_POOL_REGISTRY);
 
         // Get a random orientation for the starting piece
         WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
@@ -275,12 +274,12 @@ public class PieceLimitedJigsawManager {
 
             for (StructureTemplate.StructureBlockInfo jigsawBlock : pieceJigsawBlocks) {
                 // Gather jigsaw block information
-                Direction direction = JigsawBlock.getFrontFacing(jigsawBlock.state());
-                BlockPos jigsawBlockPos = jigsawBlock.pos();
+                Direction direction = JigsawBlock.getFrontFacing(jigsawBlock.state);
+                BlockPos jigsawBlockPos = jigsawBlock.pos;
                 BlockPos jigsawBlockTargetPos = jigsawBlockPos.relative(direction);
 
                 // Get the jigsaw block's piece pool
-                ResourceLocation jigsawBlockPool = new ResourceLocation(jigsawBlock.nbt().getString("pool"));
+                ResourceLocation jigsawBlockPool = new ResourceLocation(jigsawBlock.nbt.getString("pool"));
                 Optional<StructureTemplatePool> poolOptional = this.poolRegistry.getOptional(jigsawBlockPool);
 
                 // Only continue if we are using the jigsaw pattern registry and if it is not empty
@@ -290,7 +289,7 @@ public class PieceLimitedJigsawManager {
                 }
 
                 // Get the jigsaw block's fallback pool (which is a part of the pool's JSON)
-                Holder<StructureTemplatePool> jigsawBlockFallback = poolOptional.get().getFallback();
+                ResourceLocation fallBackPoolRL = poolOptional.get().getFallback();
 
                 // Adjustments for if the target block position is inside the current piece
                 boolean isTargetInsideCurrentPiece = pieceBoundingBox.isInside(jigsawBlockTargetPos);
@@ -315,12 +314,13 @@ public class PieceLimitedJigsawManager {
                 }
 
                 // Process the fallback pieces in the event none of the pool pieces work
+                StructureTemplatePool jigsawBlockFallback = poolRegistry.get(fallBackPoolRL);
+
                 boolean ignoreBounds = false;
                 if(poolsThatIgnoreBounds != null) {
-                    ResourceLocation fallBackPoolRL = poolRegistry.getKey(jigsawBlockFallback.value());
                     ignoreBounds = poolsThatIgnoreBounds.contains(fallBackPoolRL);
                 }
-                this.processList(new ArrayList<>(((StructurePoolAccessor)jigsawBlockFallback.value()).mes_getRawTemplates()), doBoundaryAdjustments, jigsawBlock, jigsawBlockTargetPos, pieceMinY, jigsawBlockPos, octreeToUse, piece, depth, targetPieceBoundsTop, heightLimitView, ignoreBounds);
+                this.processList(new ArrayList<>(((StructurePoolAccessor)jigsawBlockFallback).mes_getRawTemplates()), doBoundaryAdjustments, jigsawBlock, jigsawBlockTargetPos, pieceMinY, jigsawBlockPos, octreeToUse, piece, depth, targetPieceBoundsTop, heightLimitView, ignoreBounds);
             }
         }
 
@@ -428,16 +428,16 @@ public class PieceLimitedJigsawManager {
                     int candidateHeightAdjustments;
                     if (doBoundaryAdjustments && tempCandidateBoundingBox.getYSpan() <= 16) {
                         candidateHeightAdjustments = candidateJigsawBlocks.stream().mapToInt((pieceCandidateJigsawBlock) -> {
-                            if (!tempCandidateBoundingBox.isInside(pieceCandidateJigsawBlock.pos().relative(JigsawBlock.getFrontFacing(pieceCandidateJigsawBlock.state())))) {
+                            if (!tempCandidateBoundingBox.isInside(pieceCandidateJigsawBlock.pos.relative(JigsawBlock.getFrontFacing(pieceCandidateJigsawBlock.state)))) {
                                 return 0;
                             }
                             else {
-                                ResourceLocation candidateTargetPool = new ResourceLocation(pieceCandidateJigsawBlock.nbt().getString("pool"));
+                                ResourceLocation candidateTargetPool = new ResourceLocation(pieceCandidateJigsawBlock.nbt.getString("pool"));
                                 Optional<StructureTemplatePool> candidateTargetPoolOptional = this.poolRegistry.getOptional(candidateTargetPool);
                                 if (candidateTargetPoolOptional.isEmpty()) {
                                     MESCommon.LOGGER.warn("Moog's End Structures: Non-existent child pool attempted to be spawned: {} which is being called from {}. Let Moog's Voyager Structures dev (FinnDog) know about this log entry.", candidateTargetPool, candidatePiece instanceof SinglePoolElement ? ((SinglePoolElementAccessor) candidatePiece).mes_getTemplate().left().get() : "not a SinglePoolElement class");
                                 }
-                                int tallestCandidateTargetFallbackPieceHeight = candidateTargetPoolOptional.map((c) -> c.getFallback().value().getMaxSize(context.structureTemplateManager())).orElse(0);
+                                int tallestCandidateTargetFallbackPieceHeight = candidateTargetPoolOptional.map((c) -> this.poolRegistry.get(c.getFallback()).getMaxSize(context.structureTemplateManager())).orElse(0);
                                 int tallestCandidateTargetPoolPieceHeight = candidateTargetPoolOptional.map((c) -> c.getMaxSize(context.structureTemplateManager())).orElse(0);
                                 return Math.max(tallestCandidateTargetPoolPieceHeight, tallestCandidateTargetFallbackPieceHeight);
                             }
@@ -450,7 +450,7 @@ public class PieceLimitedJigsawManager {
                     // Check for each of the candidate's jigsaw blocks for a match
                     for (StructureTemplate.StructureBlockInfo candidateJigsawBlock : candidateJigsawBlocks) {
                         if (GeneralUtils.canJigsawsAttach(jigsawBlock, candidateJigsawBlock)) {
-                            BlockPos candidateJigsawBlockPos = candidateJigsawBlock.pos();
+                            BlockPos candidateJigsawBlockPos = candidateJigsawBlock.pos;
                             BlockPos candidateJigsawBlockRelativePos = new BlockPos(jigsawBlockTargetPos.getX() - candidateJigsawBlockPos.getX(), jigsawBlockTargetPos.getY() - candidateJigsawBlockPos.getY(), jigsawBlockTargetPos.getZ() - candidateJigsawBlockPos.getZ());
 
                             // Get the bounding box for the piece, offset by the relative position difference
@@ -464,7 +464,7 @@ public class PieceLimitedJigsawManager {
                             // Determine how much the candidate jigsaw block is off in the y direction.
                             // This will be needed to offset the candidate piece so that the jigsaw blocks line up properly.
                             int candidateJigsawBlockRelativeY = candidateJigsawBlockPos.getY();
-                            int candidateJigsawYOffsetNeeded = jigsawBlockRelativeY - candidateJigsawBlockRelativeY + JigsawBlock.getFrontFacing(jigsawBlock.state()).getStepY();
+                            int candidateJigsawYOffsetNeeded = jigsawBlockRelativeY - candidateJigsawBlockRelativeY + JigsawBlock.getFrontFacing(jigsawBlock.state).getStepY();
 
                             // Determine how much we need to offset the candidate piece itself in order to have the jigsaw blocks aligned.
                             // Depends on if the placement of both pieces is rigid or not

--- a/common/src/main/java/com/finndog/mes/world/structures/placements/AdvancedRandomSpread.java
+++ b/common/src/main/java/com/finndog/mes/world/structures/placements/AdvancedRandomSpread.java
@@ -3,15 +3,12 @@ package com.finndog.mes.world.structures.placements;
 import com.finndog.mes.modinit.MESStructurePlacementType;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.core.Holder;
-import net.minecraft.core.HolderSet;
-import net.minecraft.core.RegistryCodecs;
-import net.minecraft.core.Vec3i;
-import net.minecraft.core.registries.Registries;
+import net.minecraft.core.*;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.ChunkGeneratorStructureState;
+import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.levelgen.LegacyRandomSource;
+import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.WorldgenRandom;
 import net.minecraft.world.level.levelgen.structure.StructureSet;
 import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadStructurePlacement;
@@ -92,12 +89,12 @@ public class AdvancedRandomSpread extends RandomSpreadStructurePlacement {
     }
 
     @Override
-    public boolean isStructureChunk(ChunkGeneratorStructureState chunkGeneratorStructureState, int i, int j) {
-        if (!super.isStructureChunk(chunkGeneratorStructureState, i, j)) {
+    public boolean isStructureChunk(ChunkGenerator chunkGenerator, RandomState randomState, long l, int i, int j) {
+        if (!super.isStructureChunk(chunkGenerator, randomState, l, i, j)) {
             return false;
         }
         else {
-            return this.superExclusionZone.isEmpty() || !this.superExclusionZone.get().isPlacementForbidden(chunkGeneratorStructureState, i, j);
+            return this.superExclusionZone.isEmpty() || !this.superExclusionZone.get().isPlacementForbidden(chunkGenerator, randomState, l, i, j);
         }
     }
 
@@ -114,7 +111,7 @@ public class AdvancedRandomSpread extends RandomSpreadStructurePlacement {
     }
 
     @Override
-    protected boolean isPlacementChunk(ChunkGeneratorStructureState chunkGeneratorStructureState, int x, int z) {
+    protected boolean isPlacementChunk(ChunkGenerator chunkGenerator, RandomState randomState, long l, int x, int z) {
         if (minDistanceFromWorldOrigin.isPresent()) {
             int xBlockPos = x * 16;
             int zBlockPos = z * 16;
@@ -125,7 +122,7 @@ public class AdvancedRandomSpread extends RandomSpreadStructurePlacement {
             }
         }
 
-        ChunkPos chunkpos = this.getPotentialStructureChunk(chunkGeneratorStructureState.getLevelSeed(), x, z);
+        ChunkPos chunkpos = this.getPotentialStructureChunk(l, x, z);
         return chunkpos.x == x && chunkpos.z == z;
     }
 
@@ -136,14 +133,14 @@ public class AdvancedRandomSpread extends RandomSpreadStructurePlacement {
 
     public record SuperExclusionZone(HolderSet<StructureSet> otherSet, int chunkCount, Optional<Integer> allowedChunkCount) {
         public static final Codec<SuperExclusionZone> CODEC = RecordCodecBuilder.create(builder -> builder.group(
-                RegistryCodecs.homogeneousList(Registries.STRUCTURE_SET, StructureSet.DIRECT_CODEC).fieldOf("other_set").forGetter(SuperExclusionZone::otherSet),
+                RegistryCodecs.homogeneousList(Registry.STRUCTURE_SET_REGISTRY, StructureSet.DIRECT_CODEC).fieldOf("other_set").forGetter(SuperExclusionZone::otherSet),
                 Codec.intRange(1, Integer.MAX_VALUE).fieldOf("chunk_count").forGetter(SuperExclusionZone::chunkCount),
                 Codec.intRange(1, Integer.MAX_VALUE).optionalFieldOf("allowed_chunk_count").forGetter(SuperExclusionZone::allowedChunkCount)
         ).apply(builder, SuperExclusionZone::new));
 
-        boolean isPlacementForbidden(ChunkGeneratorStructureState chunkGeneratorStructureState, int l, int j) {
+        boolean isPlacementForbidden(ChunkGenerator chunkGenerator, RandomState randomState, long l, int i, int j) {
             for (Holder<StructureSet> holder : this.otherSet) {
-                if (chunkGeneratorStructureState.hasStructureChunkInRange(holder, l, j, this.chunkCount)) {
+                if (chunkGenerator.hasStructureChunkInRange(holder, randomState, l,  i, j, this.chunkCount)) {
                     return true;
                 }
             }
@@ -151,7 +148,7 @@ public class AdvancedRandomSpread extends RandomSpreadStructurePlacement {
             if (this.allowedChunkCount.isPresent() && this.allowedChunkCount.get() > this.chunkCount) {
                 boolean isAnyInRange = false;
                 for (Holder<StructureSet> holder : this.otherSet) {
-                    if (chunkGeneratorStructureState.hasStructureChunkInRange(holder, l, j, this.allowedChunkCount.get())) {
+                    if (chunkGenerator.hasStructureChunkInRange(holder, randomState, l,  i, j, this.allowedChunkCount.get())) {
                         isAnyInRange = true;
                     }
                 }

--- a/common/src/main/resources/data/mes/tags/worldgen/structure_set/common_avoid.json
+++ b/common/src/main/resources/data/mes/tags/worldgen/structure_set/common_avoid.json
@@ -1,26 +1,5 @@
 {
   "replace": false,
   "values": [
-    "minecraft:end_cities",
-    "mes:astral_hideaway",
-    "mes:enderbloom_grove",
-    "mes:enderkeep_courtyard",
-    "mes:enderskog",
-    "mes:enderwatch_tower",
-    "mes:mythic_garden",
-    "mes:phantom_citadel",
-    "mes:starlight_voyager",
-    "mes:tower",
-
-    "mes:placid_prairie",
-    "mes:monolith",
-
-    "mes:decoration",
-    "mes:astral_meteorite",
-    "mes:ender_spire",
-
-    "mes:enderpin_spikes",
-    "mes:endscraps",
-    "mes:ruined_pillar"
   ]
 }

--- a/common/src/main/resources/data/mes/worldgen/template_pool/decoration/astral_meteorite_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/decoration/astral_meteorite_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:astral_meteorite_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/decoration/ender_spire_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/decoration/ender_spire_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:ender_spire_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/decoration/enderpin_spikes_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/decoration/enderpin_spikes_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:enderpin_spikes_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/decoration/endscraps_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/decoration/endscraps_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:enderscraps_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/decoration/ruined_pillar_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/decoration/ruined_pillar_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:ruined_pillar_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/enderbloom_grove_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/enderbloom_grove_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:enderbloom_grove_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/enderkeep_courtyard_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/enderkeep_courtyard_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:enderkeep_courtyard_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/enderskog_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/enderskog_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:enderskog_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/monolith_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/monolith_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:monolith_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/mythic_garden_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/mythic_garden_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:mythic_garden_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/common/src/main/resources/data/mes/worldgen/template_pool/placid_prairie_start_pool.json
+++ b/common/src/main/resources/data/mes/worldgen/template_pool/placid_prairie_start_pool.json
@@ -1,4 +1,6 @@
 {
+  "name": "mes:placid_prairie_start_pool",
+
   "fallback": "minecraft:empty",
 
   "elements": [

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -37,18 +37,18 @@ processResources {
 
 shadowJar {
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier = "dev-shadow"
 }
 
 remapJar {
     injectAccessWidener = true
     input.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier "fabric"
+    archiveClassifier = "fabric"
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier = "dev"
 }
 
 sourcesJar {

--- a/fabric/src/main/java/com/finndog/mes/mixins/resources/BuiltInRegistriesMixin.java
+++ b/fabric/src/main/java/com/finndog/mes/mixins/resources/BuiltInRegistriesMixin.java
@@ -1,20 +1,20 @@
 package com.finndog.mes.mixins.resources;
 
 import com.finndog.mes.modinit.MESConditionsRegistry;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.data.BuiltinRegistries;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(BuiltInRegistries.class)
+@Mixin(BuiltinRegistries.class)
 public class BuiltInRegistriesMixin {
 
     /**
      * Creates and inits our custom registry at game startup
      * @author TelepathicGrunt
      */
-    @Inject(method = "<clinit>",
+    @Inject(method = "bootstrap()V",
             at = @At(value = "RETURN"))
     private static void mes_initCustomRegistries(CallbackInfo ci) {
         MESConditionsRegistry.MES_JSON_CONDITIONS_REGISTRY.init();

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
     ],
     "depends": {
         "fabricloader": ">=0.14",
-        "fabric": ">=0.83.0",
-        "minecraft": ">=1.20",
+        "fabric": ">=0.76.0",
+        "minecraft": "=1.19.2",
         "java": ">=17"
     },
     "suggests": {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -47,17 +47,17 @@ shadowJar {
     exclude "architectury.common.json"
 
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier = "dev-shadow"
 }
 
 remapJar {
     input.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier "forge"
+    archiveClassifier = "forge"
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier = "dev"
 }
 
 sourcesJar {

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml" #mandatory
-loaderVersion = "[46,)" #mandatory This is typically bumped every Minecraft version by Forge. See https://files.minecraftforge.net/ for a list of versions.
+loaderVersion = "[43,)" #mandatory This is typically bumped every Minecraft version by Forge. See https://files.minecraftforge.net/ for a list of versions.
 license = "GNU Lesser General Public License v3.0" # Review your options at https://choosealicense.com/.
 #issueTrackerURL="https://change.me.to.your.issue.tracker.example.invalid/" #optional
 [[mods]] #mandatory
@@ -19,12 +19,12 @@ Join our community here: https://discord.gg/S5nffJbuvA
 [[dependencies.mes]] #optional
 modId = "forge" #mandatory
 mandatory = true #mandatory
-versionRange = "[46,)" #mandatory
+versionRange = "[43,)" #mandatory
 ordering = "NONE" # The order that this dependency should load in relation to your mod, required to be either 'BEFORE' or 'AFTER' if the dependency is not mandatory
 side = "BOTH" # Side this dependency is applied on - 'BOTH', 'CLIENT' or 'SERVER'
 [[dependencies.mes]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.20,1.21)"
+versionRange = "[1.19.2]"
 ordering = "NONE"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,19 @@ org.gradle.jvmargs=-Xmx4G
 org.gradle.daemon=false
 
 # Project
-mod_version=1.1-1.20
+mod_version=1.1-1.19.2
 maven_group=com.finndog.mes
 mod_name=MoogsEndStructures
 mod_author=FinnDog
 archives_base_name=mes
 
 # Common
-minecraft_version=1.20
+minecraft_version=1.19.2
 enabled_platforms=fabric,forge
 
 # Forge
-forge_version=1.20-46.0.1
+forge_version=1.19.2-43.2.0
 
 # Fabric
 fabric_loader_version=0.14.21
-fabric_api_version=0.83.0+1.20
+fabric_api_version=0.76.0+1.19.2

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -80,10 +80,10 @@ do
     esac
 done
 
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-APP_NAME="Gradle"
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
+APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
@@ -143,12 +143,16 @@ fi
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case $MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -26,6 +26,7 @@ if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
 if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 


### PR DESCRIPTION
* changed build script due to problems (`classifier` -> `archiveClassifier =`)
* emptied avoid list due to stackoverflow (you cannot have structure A and B avoid each other - either tell A to avoid B or tell B to avoid A but not both)

Also for Fabric `BuiltInRegistriesMixin` is unused
Is that intended?